### PR TITLE
fix: pin release-service-catalog revision in e2e

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -63,13 +63,13 @@ jobs:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: false
-          
+
           docker-images: false
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
-  
+
       - name: Disable AppArmor
         # works around a change in ubuntu 24.04 that restricts Linux namespace access
         # for unprivileged users
@@ -79,7 +79,7 @@ jobs:
         uses: helm/kind-action@v1
         with:
           config: kind-config.yaml
-      
+
       - name: Show version information
         run: |
           kubectl version
@@ -137,6 +137,7 @@ jobs:
           GH_ORG: ${{ secrets.GH_ORG }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QUAY_DOCKERCONFIGJSON: ${{ secrets.QUAY_DOCKERCONFIGJSON }}
+          RELEASE_SERVICE_CATALOG_REVISION: ${{ secrets.RELEASE_SERVICE_CATALOG_REVISION }}
         run: |
           ./test/e2e/run-e2e.sh
 

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -9,7 +9,22 @@ main() {
     local github_org="${GH_ORG:?A GitHub org where the https://github.com/redhat-appstudio-qe/konflux-ci-sample repo is present/forked should be provided}"
     local github_token="${GH_TOKEN:?A GitHub token should be provided}"
     local quay_dockerconfig="${QUAY_DOCKERCONFIGJSON:?quay.io credentials in .dockerconfig format should be provided}"
-    docker run --network=host -v ~/.kube/config:/kube/config --env KUBECONFIG=/kube/config -e GITHUB_TOKEN="$github_token" -e QUAY_TOKEN="$(base64 <<< "$quay_dockerconfig")" -e MY_GITHUB_ORG="$github_org" -e E2E_APPLICATIONS_NAMESPACE=user-ns2 -e TEST_ENVIRONMENT=upstream "$E2E_TEST_IMAGE"  /bin/bash -c "ginkgo -v --label-filter=upstream-konflux --focus=\"Test local\" /konflux-e2e/konflux-e2e.test"
+    local catalog_revision="${RELEASE_SERVICE_CATALOG_REVISION:-development}"
+
+    echo "Using release-service-catalog revision: $catalog_revision" >&2
+
+    docker run \
+        --network=host \
+        -v ~/.kube/config:/kube/config \
+        --env KUBECONFIG=/kube/config \
+        -e GITHUB_TOKEN="$github_token" \
+        -e QUAY_TOKEN="$(base64 <<< "$quay_dockerconfig")" \
+        -e MY_GITHUB_ORG="$github_org" \
+        -e E2E_APPLICATIONS_NAMESPACE=user-ns2 \
+        -e TEST_ENVIRONMENT=upstream \
+        -e RELEASE_SERVICE_CATALOG_REVISION="$catalog_revision" \
+        "$E2E_TEST_IMAGE" \
+        /bin/bash -c "ginkgo -v --label-filter=upstream-konflux --focus=\"Test local\" /konflux-e2e/konflux-e2e.test"
 }
 
 


### PR DESCRIPTION
The pipeline we're using during release underwent some breaking changes. Until the latest revision is usable for us again, we need to make sure we're using an older revision.